### PR TITLE
Find executable using 'which' for machinectl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,7 @@ dependencies = [
  "posix-acl",
  "simple-error",
  "users",
+ "which",
 ]
 
 [[package]]
@@ -153,6 +154,15 @@ name = "vec_map"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+
+[[package]]
+name = "which"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5475d47078209a02e60614f7ba5e645ef3ed60f771920ac1906d7c1cc65024c8"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ posix-acl = "0.3.0"
 clap = "2.33.0"
 log = {version = "0.4.8", features = ["std"]}
 ansi_term = "0.12.1"
+which = {version = "3.1.0", default-features = false}

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,6 @@ use log::{debug, error, info, Level};
 use posix_acl::{PosixACL, Qualifier, ACL_EXECUTE, ACL_READ, ACL_RWX};
 use simple_error::SimpleError;
 use users::{get_user_by_name, uid_t};
-
 use which::which;
 
 type AnyErr = Box<dyn Error>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,8 @@ use posix_acl::{PosixACL, Qualifier, ACL_EXECUTE, ACL_READ, ACL_RWX};
 use simple_error::SimpleError;
 use users::{get_user_by_name, uid_t};
 
+use which::which;
+
 type AnyErr = Box<dyn Error>;
 
 mod logging;
@@ -376,7 +378,19 @@ fn run_machinectl_command(
     args.extend(envvars.iter().map(|v| format!("-E{}", v)));
     args.push("--".to_string());
     args.push(".host".to_string());
-    args.extend(remote_cmd);
+
+    if !remote_cmd.is_empty() {
+        let cmd = &remote_cmd[0];
+        if cmd.starts_with('/') {
+            // OK, command name already absolute.
+            args.extend(remote_cmd)
+        } else {
+            // machinectl requires absolute executable path, resolve it...
+            let path = try_with!(which(cmd), "Cannot find executable '{}'", cmd);
+            args.push(path.to_str().expect("Invalid path").into());
+            args.extend(remote_cmd.iter().skip(1).cloned());
+        }
+    }
 
     info!("Running command: machinectl {}", args.join(" "));
     Command::new("machinectl").args(args).exec();


### PR DESCRIPTION
The machinectl command requires absolute executable path.