### PR TITLE
Enable CI tests on pull requests and weekly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,14 @@
 name: Tests
-on: [push]
+on:
+  push:
+    branches: [master]
+  pull_request:
+  schedule:
+    # 16:21 UTC on Tuesdays
+    - cron: "21 16 * * tue"
+  repository_dispatch:
+    types: [tests]
+
 env:
   DOCKER_BUILDKIT: 1
 jobs:


### PR DESCRIPTION
* Pull requests from foreign repositories weren't being tested. :(
* Also test master branch on weekly schedule