### PR TITLE
Run machinectl remote commands via /bin/sh (preparing for #6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,9 +73,9 @@ dependencies = [
  "clap",
  "log",
  "posix-acl",
+ "shell-words",
  "simple-error",
  "users",
- "which",
 ]
 
 [[package]]
@@ -113,22 +113,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.18"
+name = "shell-words"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
-dependencies = [
- "unicode-xid",
-]
-
-[[package]]
-name = "quote"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
-dependencies = [
- "proc-macro2",
-]
+checksum = "b6fa3938c99da4914afedd13bf3d79bcb6c277d1b2c398d23257a304d9e1b074"
 
 [[package]]
 name = "simple-error"
@@ -143,17 +131,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
-name = "syn"
-version = "1.0.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cae2873c940d92e697597c5eee105fb570cd5689c695806f672883653349b"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,36 +140,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "unicode-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "users"
@@ -209,16 +160,6 @@ name = "vec_map"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
-
-[[package]]
-name = "which"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5fe1a9cb33fe7cf77d431070d0223e544b1e4e7f7764bad0a3e691a6678a131"
-dependencies = [
- "libc",
- "thiserror",
-]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ posix-acl = "1.0.0"
 clap = "2.33.1"
 log = {version = "0.4.11", features = ["std"]}
 ansi_term = "0.12.1"
-which = {version = "4.0.1", default-features = false}
+shell-words = "1.0.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,7 @@ fn getenv_path(key: &str) -> Result<PathBuf, SimpleError> {
     }
 }
 
-/// Get details of *target* user, also formats a nice user-friendly message with instructions.
+/// Get details of *target* user; on error, formats a nice user-friendly message with instructions.
 fn get_target_user(username: &str) -> Result<User, ErrorWithHint> {
     if let Some(user) = get_user_by_name(&username) {
         return Ok(user);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -11,6 +11,7 @@ fn test_context() -> EgoContext {
         runtime_dir: "/run/user/1000".into(),
         target_user: "ego".into(),
         target_uid: 155,
+        target_user_shell: "/bin/bash".into(),
     }
 }
 


### PR DESCRIPTION
* This is a pre-requisite to solve #6 in a future change.
* If no arguments are specified, explicitly use the target user's default shell.
* Replaced `which` dependency with `shell-words`.