### PR TITLE
Launch xdg-desktop-portal-gtk in machinectl session (fixes #6)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -45,7 +45,7 @@ pub fn parse_args<T: Into<OsString> + Clone>(args: impl IntoIterator<Item = T>) 
                 .long("machinectl-bare")
                 .help("Use 'machinectl' but skip xdg-desktop-portal setup"),
         )
-        .group(ArgGroup::with_name("method").args(&["sudo", "machinectl"]))
+        .group(ArgGroup::with_name("method").args(&["sudo", "machinectl", "machinectl-bare"]))
         .arg(
             Arg::with_name("command")
                 .help("Command name and arguments to run (default: user shell)")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,7 @@ use std::ffi::OsString;
 pub enum Method {
     Sudo,
     Machinectl,
+    MachinectlBare,
 }
 
 /// Data type for parsed settings
@@ -39,6 +40,11 @@ pub fn parse_args<T: Into<OsString> + Clone>(args: impl IntoIterator<Item = T>) 
                 .long("machinectl")
                 .help("Use 'machinectl' to change user"),
         )
+        .arg(
+            Arg::with_name("machinectl-bare")
+                .long("machinectl-bare")
+                .help("Use 'machinectl' but skip xdg-desktop-portal setup"),
+        )
         .group(ArgGroup::with_name("method").args(&["sudo", "machinectl"]))
         .arg(
             Arg::with_name("command")
@@ -69,6 +75,8 @@ pub fn parse_args<T: Into<OsString> + Clone>(args: impl IntoIterator<Item = T>) 
         },
         method: if matches.is_present("machinectl") {
             Method::Machinectl
+        } else if matches.is_present("machinectl-bare") {
+            Method::MachinectlBare
         } else {
             Method::Sudo
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -344,7 +344,7 @@ fn machinectl_remote_command(remote_cmd: Vec<String>, envvars: Vec<String>, bare
         cmd.push_str("systemctl --user start xdg-desktop-portal-gtk; ");
     }
     cmd.push_str(&format!("exec -- {}", shell_words::join(remote_cmd)));
-    return cmd;
+    cmd
 }
 
 fn run_machinectl_command(

--- a/varia/ego-completion.zsh
+++ b/varia/ego-completion.zsh
@@ -9,6 +9,7 @@ function _ego {
         {-v,--verbose}'[Verbose output]' \
         '--sudo[Execute using sudo]' \
         '--machinectl[Execute using machinectl]' \
+        '--machinectl-bare[Execute using machinectl but skip xdg-desktop-portal setup]' \
         '--[]' \
         '(-)1:command: _command_names -e' \
         '*::arguments: _normal'


### PR DESCRIPTION
Old behavior is available with `--machinectl-bare` switch.