### PR TITLE
Fix --machinectl on Ubuntu, Debian (dash shell)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ your own username):
 
 Changelog
 ---------
+##### Unreleased
+* Fix `--machinectl` on Ubuntu, Debian with dash shell (#42)
+
 ##### 0.4.0 (2021-01-29)
 * Improved integration with desktop environments:
   * Launch xdg-desktop-portal-gtk in machinectl session (#6, #31)

--- a/src/main.rs
+++ b/src/main.rs
@@ -343,7 +343,7 @@ fn machinectl_remote_command(remote_cmd: Vec<String>, envvars: Vec<String>, bare
         // XXX what happens if the desktop-portal is already running but with an outdated environment?
         cmd.push_str("systemctl --user start xdg-desktop-portal-gtk; ");
     }
-    cmd.push_str(&format!("exec -- {}", shell_words::join(remote_cmd)));
+    cmd.push_str(&format!("exec {}", shell_words::join(remote_cmd)));
     cmd
 }
 


### PR DESCRIPTION
Turns out that the dash shell, default /bin/sh on Ubuntu and Debian, does not support `exec -- <cmd>` syntax. Omit `--` from the command line.