### PR TITLE
Fix error reporting when executing command

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Changelog
 ---------
 ##### Unreleased
 * Fix `--machinectl` on Ubuntu, Debian with dash shell (#42)
+* Fix error reporting when command execution fails (#43)
 
 ##### 0.4.0 (2021-01-29)
 * Improved integration with desktop environments:

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -26,15 +26,15 @@ impl Error for ErrorWithHint {}
 impl fmt::Display for ErrorWithHint {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.err.fmt(f)
+        self.err.fmt(f)?;
+
+        if !self.hint.is_empty() {
+            write!(f, "\n{}: {}", Green.paint("hint"), self.hint)?;
+        }
+        Ok(())
     }
 }
 
 pub fn print_error(err: AnyErr) {
-    // Look ma', dynamic typing in Rust!
-    if let Some(errhint) = err.downcast_ref::<ErrorWithHint>() {
-        error!("{}\n{}: {}", errhint.err, Green.paint("hint"), errhint.hint);
-    } else {
-        error!("{}", err);
-    }
+    error!("{}", err);
 }


### PR DESCRIPTION
Doh, major omission in error reporting! :(

Also simplified printing of `ErrorWithHint`.