### PR TITLE
Enable sudo askpass helper if SUDO_ASKPASS is set

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -347,7 +347,12 @@ fn run_sudo_command(
         );
     }
 
-    let mut args = vec!["-SHiu".to_string(), ctx.target_user.clone()];
+    let mut args = vec!["-Hiu".to_string(), ctx.target_user.clone()];
+    // If SUDO_ASKPASS envvar is set, add -A argument to use the askpass agent
+    if let Ok(Some(_)) = getenv_optional("SUDO_ASKPASS") {
+        debug!("SUDO_ASKPASS detected");
+        args.push("-A".into())
+    }
     args.extend(envvars);
     args.extend(remote_cmd);
 


### PR DESCRIPTION
Ego now detects the `SUDO_ASKPASS` environment variable and passes the `-A` argument to `sudo` to enable it. This allows using a GUI password prompt. Refs #57.

Example here how to set up `zenity` GUI password prompt: https://askubuntu.com/questions/314395/proper-way-to-let-user-enter-password-for-a-bash-script-using-only-the-gui-with
