### PR TITLE
Upgrade to clap 3.0.0 stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,41 +51,24 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.0.0-beta.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
+checksum = "d17bf219fcd37199b9a29e00ba65dfb8cd5b2688b7297ec14ff829c40ac50ca9"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
  "indexmap",
- "lazy_static",
  "os_str_bytes",
  "strsim",
  "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
 ]
 
 [[package]]
-name = "clap_derive"
-version = "3.0.0-beta.5"
+name = "clap_complete"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b15c6b4f786ffb6192ffe65a36855bc1fc2444bcd0945ae16748dcd6ed7d0d3"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "clap_generate"
-version = "3.0.0-beta.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adf420f8b687b628d2915ccfd43a660c437a170432e3fbcb66944e8717a0d68f"
+checksum = "60d123fbea4c5d9799cffd44051e2125c880efd23b3b7c529baf3ea5508c8736"
 dependencies = [
  "clap",
 ]
@@ -96,7 +79,7 @@ version = "1.1.3"
 dependencies = [
  "ansi_term",
  "clap",
- "clap_generate",
+ "clap_complete",
  "log",
  "posix-acl",
  "shell-words",
@@ -109,15 +92,6 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -139,12 +113,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,10 +128,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "2.4.0"
+name = "memchr"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "posix-acl"
@@ -173,48 +150,6 @@ checksum = "2ea5dae99e4365fa738533b43f4c649c0450ba7fbb81a984a4fba6a42ce91812"
 dependencies = [
  "acl-sys",
  "libc",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "1.0.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
-dependencies = [
- "unicode-xid",
-]
-
-[[package]]
-name = "quote"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
-dependencies = [
- "proc-macro2",
 ]
 
 [[package]]
@@ -236,17 +171,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "syn"
-version = "1.0.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,30 +181,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "users"
@@ -291,18 +194,6 @@ dependencies = [
  "libc",
  "log",
 ]
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "version_check"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["command-line-utilities"]
 users = "0.11.0"
 simple-error = "0.2.3"
 posix-acl = "1.0.0"
-clap = "=3.0.0-beta.2"
+clap = "3.0.0"
 log = { version = "0.4.14", features = ["std"] }
 ansi_term = "0.12.1"
 shell-words = "1.0.0"
@@ -28,4 +28,4 @@ default = []
 update-snapshots = []
 
 [dev-dependencies]
-clap_generate = "=3.0.0-beta.2"
+clap_complete = "3.0.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,37 +20,36 @@ pub struct Args {
 pub fn build_cli() -> App<'static> {
     App::new("Alter Ego: run desktop applications under a different local user")
         .setting(AppSettings::TrailingVarArg)
-        .setting(AppSettings::DisableVersion)
-        .setting(AppSettings::ColoredHelp)
+        .setting(AppSettings::DisableVersionFlag)
         .arg(
             Arg::new("user")
                 .short('u')
                 .long("user")
                 .value_name("USER")
-                .about("Specify a username (default: ego)")
+                .help("Specify a username (default: ego)")
                 .takes_value(true)
                 .value_hint(ValueHint::Username),
         )
         .arg(
             Arg::new("sudo")
                 .long("sudo")
-                .about("Use 'sudo' to change user"),
+                .help("Use 'sudo' to change user"),
         )
         .arg(
             Arg::new("machinectl")
                 .long("machinectl")
-                .about("Use 'machinectl' to change user (default, if available)"),
+                .help("Use 'machinectl' to change user (default, if available)"),
         )
         .arg(
             Arg::new("machinectl-bare")
                 .long("machinectl-bare")
-                .about("Use 'machinectl' but skip xdg-desktop-portal setup"),
+                .help("Use 'machinectl' but skip xdg-desktop-portal setup"),
         )
         .group(ArgGroup::new("method").args(&["sudo", "machinectl", "machinectl-bare"]))
         .arg(
             Arg::new("command")
-                .about("Command name and arguments to run (default: user shell)")
-                .multiple(true)
+                .help("Command name and arguments to run (default: user shell)")
+                .multiple_values(true)
                 .value_hint(ValueHint::CommandWithArguments),
         )
         .arg(
@@ -58,7 +57,7 @@ pub fn build_cli() -> App<'static> {
                 .short('v')
                 .long("verbose")
                 .multiple_occurrences(true)
-                .about("Verbose output. Use multiple times for more output."),
+                .help("Verbose output. Use multiple times for more output."),
         )
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -44,7 +44,10 @@ fn render_completion(generator: impl Generator) -> Vec<u8> {
     let mut buf = Vec::<u8>::new();
     let mut app = build_cli();
     clap_complete::generate(generator, &mut app, "ego", &mut buf);
-    buf.write_all(b"\n").unwrap();
+    // XXX clap_complete doesn't append newline to zsh completions.
+    if !buf.ends_with(b"\n") {
+        buf.push(b'\n');
+    }
 
     buf
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,8 +2,8 @@ use crate::cli::{build_cli, parse_args, Method};
 use crate::util::have_command;
 use crate::{get_wayland_socket, EgoContext};
 use ansi_term::Colour::{Cyan, Red};
-use clap_generate::generators::{Bash, Fish, Zsh};
-use clap_generate::Generator;
+use clap_complete::shells::{Bash, Fish, Zsh};
+use clap_complete::Generator;
 use log::Level;
 use std::env;
 use std::fs::File;
@@ -40,10 +40,10 @@ fn snapshot_match(path: &str, data: &[u8]) {
     }
 }
 
-fn render_completion<G: Generator>() -> Vec<u8> {
+fn render_completion(shell: impl Generator) -> Vec<u8> {
     let mut buf = Vec::<u8>::new();
     let mut app = build_cli();
-    clap_generate::generate::<G, _>(&mut app, "ego", &mut buf);
+    clap_complete::generate(shell, &mut app, "ego", &mut buf);
     buf.write_all(b"\n").unwrap();
 
     buf
@@ -62,9 +62,9 @@ fn render_completion<G: Generator>() -> Vec<u8> {
 /// ```
 #[test]
 fn shell_completions() {
-    snapshot_match("varia/ego-completion.zsh", &render_completion::<Zsh>());
-    snapshot_match("varia/ego-completion.bash", &render_completion::<Bash>());
-    snapshot_match("varia/ego-completion.fish", &render_completion::<Fish>());
+    snapshot_match("varia/ego-completion.zsh", &render_completion(Zsh));
+    snapshot_match("varia/ego-completion.bash", &render_completion(Bash));
+    snapshot_match("varia/ego-completion.fish", &render_completion(Fish));
 }
 
 fn test_context() -> EgoContext {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -40,10 +40,10 @@ fn snapshot_match(path: &str, data: &[u8]) {
     }
 }
 
-fn render_completion(shell: impl Generator) -> Vec<u8> {
+fn render_completion(generator: impl Generator) -> Vec<u8> {
     let mut buf = Vec::<u8>::new();
     let mut app = build_cli();
-    clap_complete::generate(shell, &mut app, "ego", &mut buf);
+    clap_complete::generate(generator, &mut app, "ego", &mut buf);
     buf.write_all(b"\n").unwrap();
 
     buf
@@ -52,7 +52,7 @@ fn render_completion(shell: impl Generator) -> Vec<u8> {
 /// Unit tests may seem like a weird place to update shell completion files, but this is like
 /// snapshot testing, which guarantees the file is never out of date.
 ///
-/// Also we don't have to lug around `clap_generate` code in the `ego` binary itself.
+/// Also we don't have to lug around `clap_complete` code in the `ego` binary itself.
 ///
 /// run 'cargo test --features=update-snapshots' to update
 ///

--- a/varia/ego-completion.bash
+++ b/varia/ego-completion.bash
@@ -9,10 +9,9 @@ _ego() {
     for i in ${COMP_WORDS[@]}
     do
         case "${i}" in
-            ego)
+            "$1")
                 cmd="ego"
                 ;;
-            
             *)
                 ;;
         esac
@@ -20,18 +19,17 @@ _ego() {
 
     case "${cmd}" in
         ego)
-            opts=" -u -v -h  --user --sudo --machinectl --machinectl-bare --verbose --help  <command>... "
+            opts="-h -u -v --help --user --sudo --machinectl --machinectl-bare --verbose <command>..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                
                 --user)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -u)
+                -u)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -42,7 +40,6 @@ _ego() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        
     esac
 }
 

--- a/varia/ego-completion.bash
+++ b/varia/ego-completion.bash
@@ -44,4 +44,3 @@ _ego() {
 }
 
 complete -F _ego -o bashdefault -o default ego
-

--- a/varia/ego-completion.fish
+++ b/varia/ego-completion.fish
@@ -1,7 +1,7 @@
-complete -c ego -n "__fish_use_subcommand" -s u -l user -d 'Specify a username (default: ego)' -r -f -a "(__fish_complete_users)"
-complete -c ego -n "__fish_use_subcommand" -l sudo -d 'Use \'sudo\' to change user'
-complete -c ego -n "__fish_use_subcommand" -l machinectl -d 'Use \'machinectl\' to change user (default, if available)'
-complete -c ego -n "__fish_use_subcommand" -l machinectl-bare -d 'Use \'machinectl\' but skip xdg-desktop-portal setup'
-complete -c ego -n "__fish_use_subcommand" -s v -l verbose -d 'Verbose output. Use multiple times for more output.'
-complete -c ego -n "__fish_use_subcommand" -s h -l help -d 'Prints help information'
+complete -c ego -s u -l user -d 'Specify a username (default: ego)' -r -f -a "(__fish_complete_users)"
+complete -c ego -s h -l help -d 'Print help information'
+complete -c ego -l sudo -d 'Use \'sudo\' to change user'
+complete -c ego -l machinectl -d 'Use \'machinectl\' to change user (default, if available)'
+complete -c ego -l machinectl-bare -d 'Use \'machinectl\' but skip xdg-desktop-portal setup'
+complete -c ego -s v -l verbose -d 'Verbose output. Use multiple times for more output.'
 

--- a/varia/ego-completion.fish
+++ b/varia/ego-completion.fish
@@ -4,4 +4,3 @@ complete -c ego -l sudo -d 'Use \'sudo\' to change user'
 complete -c ego -l machinectl -d 'Use \'machinectl\' to change user (default, if available)'
 complete -c ego -l machinectl-bare -d 'Use \'machinectl\' but skip xdg-desktop-portal setup'
 complete -c ego -s v -l verbose -d 'Verbose output. Use multiple times for more output.'
-

--- a/varia/ego-completion.zsh
+++ b/varia/ego-completion.zsh
@@ -15,25 +15,22 @@ _ego() {
 
     local context curcontext="$curcontext" state line
     _arguments "${_arguments_options[@]}" \
-'-u+[Specify a username (default: ego)]: :_users' \
-'--user=[Specify a username (default: ego)]: :_users' \
+'-u+[Specify a username (default: ego)]:USER:_users' \
+'--user=[Specify a username (default: ego)]:USER:_users' \
+'-h[Print help information]' \
+'--help[Print help information]' \
 '--sudo[Use '\''sudo'\'' to change user]' \
 '--machinectl[Use '\''machinectl'\'' to change user (default, if available)]' \
 '--machinectl-bare[Use '\''machinectl'\'' but skip xdg-desktop-portal setup]' \
 '*-v[Verbose output. Use multiple times for more output.]' \
 '*--verbose[Verbose output. Use multiple times for more output.]' \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
 '*::command -- Command name and arguments to run (default\: user shell):_cmdambivalent' \
 && ret=0
-    
 }
 
 (( $+functions[_ego_commands] )) ||
 _ego_commands() {
-    local commands; commands=(
-        
-    )
+    local commands; commands=()
     _describe -t commands 'ego commands' commands "$@"
 }
 


### PR DESCRIPTION
Previously `ego` was using a beta version of `clap`, which also caused some issues (#65, #68).