### PR TITLE
Document xhost requirement, improve xhost error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Ego aims to come with sane defaults and be easy to set up.
 **Requirements:**
 * [Rust & cargo](https://www.rust-lang.org/tools/install)
 * `libacl.so` library (Debian/Ubuntu: libacl1-dev; Fedora: libacl-devel; Arch: acl)
+* `xhost` binary (Debian/Ubuntu: x11-xserver-utils; Fedora: xorg-xhost; Arch: xorg-xhost)
 
 **Recommended:** (Not needed when using `--sudo` mode, but some desktop functionality may not work).
 * `machinectl` command (Debian/Ubuntu/Fedora: systemd-container; Arch: systemd)

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use crate::{ErrorWithHint};
+use crate::ErrorWithHint;
 use log::debug;
 use std::io::ErrorKind;
 use std::os::unix::prelude::CommandExt;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,10 @@
-use std::env;
+use crate::{ErrorWithHint};
+use log::debug;
+use std::io::ErrorKind;
+use std::os::unix::prelude::CommandExt;
 use std::path::Path;
+use std::process::{Command, Output};
+use std::{env, io};
 
 /// Detect if system was booted with systemd init system. Same logic as sd_booted() in libsystemd.
 /// https://www.freedesktop.org/software/systemd/man/sd_booted.html
@@ -13,4 +18,46 @@ pub fn have_command<P: AsRef<Path>>(exe_name: P) -> bool {
     env::var_os("PATH").map_or(false, |paths| {
         env::split_paths(&paths).any(|dir| dir.join(&exe_name).is_file())
     })
+}
+
+fn report_command_error(err: io::Error, program: &str, args: &[String]) -> ErrorWithHint {
+    ErrorWithHint::new(
+        format!("Failed to run {}: {}", program, err),
+        if err.kind() == ErrorKind::NotFound {
+            format!("Try installing package that contains command '{}'", program)
+        } else {
+            format!("Complete command: {} {}", program, shell_words::join(args))
+        },
+    )
+}
+
+/// Exec command (ending the current process) or return error.
+pub fn exec_command(program: &str, args: &[String]) -> Result<(), ErrorWithHint> {
+    debug!("Executing: {} {}", program, shell_words::join(args));
+    // If this call returns at all, it was an error
+    let err: io::Error = Command::new(program).args(args).exec();
+
+    Err(report_command_error(err, program, args))
+}
+
+/// Run command as subprocess. Return output if status was 0, otherwise return as error.
+pub fn run_command(program: &str, args: &[String]) -> Result<Output, ErrorWithHint> {
+    debug!("Running: {} {}", program, shell_words::join(args));
+    let ret = Command::new(program)
+        .args(args)
+        .output()
+        .map_err(|err| report_command_error(err, program, args))?;
+
+    if !ret.status.success() {
+        return Err(ErrorWithHint::new(
+            format!(
+                "{} returned {}:\n{}",
+                program,
+                ret.status.code().unwrap_or(999),
+                String::from_utf8_lossy(&ret.stderr).trim()
+            ),
+            format!("Complete command: {} {}", program, shell_words::join(args)),
+        ));
+    }
+    Ok(ret)
 }


### PR DESCRIPTION
This should greatly clarify the situation reported in #66.

Refactored command execution functions into `util.rs`, created helper `run_command()`.

Output now if `xhost` is missing:
```
error: Error preparing X11: Failed to run xhost: No such file or directory (os error 2)
hint: Try installing package that contains command 'xhost'
```