### PR TITLE
Prepare for 1.1.5 release (fix regression in 1.1.4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "ego"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "ansi_term",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ego"
-version = "1.1.4"
+version = "1.1.5"
 edition = "2018"
 
 # Metadata

--- a/README.md
+++ b/README.md
@@ -81,9 +81,11 @@ For sudo, add the following to `/etc/sudoers` (replace `<myname>` with your own 
 Changelog
 ---------
 
-##### 1.1.4 (2022-01-02)
+##### 1.1.5 (2022-01-02)
 * Document xhost requirement, improve xhost error reporting (#76)
 * Upgrade to clap 3.0.0 stable (#71)
+
+(Version 1.1.4 was yanked, it was accidentally released with a regression)
 
 ##### 1.1.3 (2021-11-12)
 * Pin clap version (fixes #65) (#68)

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,7 +193,7 @@ fn prepare_x11(ctx: &EgoContext) -> Result<Vec<String>, AnyErr> {
         return Ok(vec![]);
     }
 
-    let grant = format!("-ak +si:localuser:{}", ctx.target_user);
+    let grant = format!("+si:localuser:{}", ctx.target_user);
     run_command("xhost", &[grant])?;
     // TODO should also test /tmp/.X11-unix/X0 permissions?
 


### PR DESCRIPTION
Fixes glaring regression introduced in #76.