### PR TITLE
Update dependencies clap, shell-words

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
@@ -51,9 +51,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17bf219fcd37199b9a29e00ba65dfb8cd5b2688b7297ec14ff829c40ac50ca9"
+checksum = "e5f1fea81f183005ced9e59cdb01737ef2423956dac5a6d731b06b2ecfaa3467"
 dependencies = [
  "atty",
  "bitflags",
@@ -66,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60d123fbea4c5d9799cffd44051e2125c880efd23b3b7c529baf3ea5508c8736"
+checksum = "23eec4dd324308f49d8bf86a2732078c34d57955fec1e1d865554fc37c15d420"
 dependencies = [
  "clap",
 ]
@@ -104,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "log"
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "shell-words"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fa3938c99da4914afedd13bf3d79bcb6c277d1b2c398d23257a304d9e1b074"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "simple-error"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,14 @@ categories = ["command-line-utilities"]
 users = "0.11.0"
 simple-error = "0.2.3"
 posix-acl = "1.0.0"
-clap = "3.0.0"
+clap = "3.1.0"
 log = { version = "0.4.14", features = ["std"] }
 ansi_term = "0.12.1"
-shell-words = "1.0.0"
+shell-words = "1.1.0"
 
 [features]
 default = []
 update-snapshots = []
 
 [dev-dependencies]
-clap_complete = "3.0.0"
+clap_complete = "3.1.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{App, AppSettings, Arg, ArgGroup, ValueHint};
+use clap::{Arg, ArgGroup, Command, ValueHint};
 use log::Level;
 use std::ffi::OsString;
 
@@ -17,10 +17,10 @@ pub struct Args {
     pub method: Option<Method>,
 }
 
-pub fn build_cli() -> App<'static> {
-    App::new("Alter Ego: run desktop applications under a different local user")
-        .setting(AppSettings::TrailingVarArg)
-        .setting(AppSettings::DisableVersionFlag)
+pub fn build_cli() -> Command<'static> {
+    Command::new("Alter Ego: run desktop applications under a different local user")
+        .trailing_var_arg(true)
+        .disable_version_flag(true)
         .arg(
             Arg::new("user")
                 .short('u')


### PR DESCRIPTION
Clap update required manual code changes.

Closes #79, closes #80, closes #81.
