### PR TITLE
Ignore new Clippy format_push_string lint

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -337,6 +337,7 @@ fn run_sudo_command(
     Ok(())
 }
 
+#[allow(clippy::format_push_string)]
 fn machinectl_remote_command(remote_cmd: Vec<String>, envvars: Vec<String>, bare: bool) -> String {
     let mut cmd = String::new();
 


### PR DESCRIPTION
The suggested changes turn infallible code into one that ignores errors, not good! I'll just ignore this lint for now.

See also https://github.com/rust-lang/rust-clippy/issues/9077#issuecomment-1182373515
