### PR TITLE
Use snapbox instead of hand-coded snapshot testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "concolor"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "015267563b1df20adccdd00cb05257b1dfbea70a04928e9cf88ffb850c1a40af"
+dependencies = [
+ "atty",
+ "bitflags",
+ "concolor-query",
+]
+
+[[package]]
+name = "concolor-query"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6417fe6fc03a8b533fd2177742eeb39a90c7233eedec7bac96d4d6b69a09449"
+
+[[package]]
 name = "ego"
 version = "1.1.5"
 dependencies = [
@@ -85,6 +102,7 @@ dependencies = [
  "posix-acl",
  "shell-words",
  "simple-error",
+ "snapbox",
  "users",
 ]
 
@@ -113,6 +131,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,10 +159,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
+name = "similar"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ac7f900db32bf3fd12e0117dd3dc4da74bc52ebaac97f39668446d89694803"
+
+[[package]]
 name = "simple-error"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc47a29ce97772ca5c927f75bac34866b16d64e07f330c3248e2d7226623901b"
+
+[[package]]
+name = "snapbox"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98a96656eecd1621c5830831b48eb6903a9f86aaeb61b9f358a9bd462414ddd"
+dependencies = [
+ "concolor",
+ "normalize-line-endings",
+ "similar",
+ "snapbox-macros",
+ "yansi",
+]
+
+[[package]]
+name = "snapbox-macros"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "485e65c1203eb37244465e857d15a26d3a85a5410648ccb53b18bd44cb3a7336"
 
 [[package]]
 name = "strsim"
@@ -195,3 +244,9 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ shell-words = "1.1.0"
 
 [features]
 default = []
-update-snapshots = []
 
 [dev-dependencies]
 clap_complete = "4.0.1"
+snapbox = "0.4.0"

--- a/src/snapshots/ego.help
+++ b/src/snapshots/ego.help
@@ -1,0 +1,12 @@
+Usage: Alter Ego: run desktop applications under a different local user [OPTIONS] [command]...
+
+Arguments:
+  [command]...  Command name and arguments to run (default: user shell)
+
+Options:
+  -u, --user <USER>      Specify a username (default: ego) [default: ego]
+      --sudo             Use 'sudo' to change user
+      --machinectl       Use 'machinectl' to change user (default, if available)
+      --machinectl-bare  Use 'machinectl' but skip xdg-desktop-portal setup
+  -v, --verbose...       Verbose output. Use multiple times for more output.
+  -h, --help             Print help information

--- a/varia/README.md
+++ b/varia/README.md
@@ -7,7 +7,7 @@ For shell completions to work, these files should be installed as:
 * `ego-completion.fish` → `/usr/share/fish/vendor_completions.d/ego.fish`
 
 These files are auto-generated with `clap_generate`. To update them, run
-`cargo test --features=update-snapshots`
+`SNAPSHOTS=overwrite cargo test`
 
 Packaging ego
 -------------


### PR DESCRIPTION
snapbox provides very nice diff output.

Also added snapshot test for `ego --help` output (and found a bug, doh!)