### PR TITLE
Update to Rust edition 2021 & add MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "ego"
 version = "1.1.5"
-edition = "2018"
+edition = "2021"
+rust-version = "1.60.0"
 
 # Metadata
 authors = ["Marti Raudsepp <marti@juffo.org>"]


### PR DESCRIPTION
Ego's minimum supported Rust version (MSRV) is 1.60.0, which already supports edition 2021 so there is no downside with this.