### PR TITLE
Satisfy Clippy: Use variables directly in format strings

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,1 @@
+allow-mixed-uninlined-format-args = false

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -36,5 +36,5 @@ impl fmt::Display for ErrorWithHint {
 }
 
 pub fn print_error(err: AnyErr) {
-    error!("{}", err);
+    error!("{err}");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,15 +117,14 @@ fn get_target_user(username: &str) -> Result<User, ErrorWithHint> {
     for uid in 150..=499 {
         if get_user_by_uid(uid).is_none() {
             hint = format!(
-                "{} with the command:\n    sudo useradd '{}' --uid {} --create-home",
-                hint, username, uid
+                "{hint} with the command:\n    sudo useradd '{username}' --uid {uid} --create-home"
             );
             break;
         }
     }
 
     Err(ErrorWithHint::new(
-        format!("Unknown user '{}'", username),
+        format!("Unknown user '{username}'"),
         hint,
     ))
 }
@@ -368,7 +367,7 @@ fn run_machinectl_command(
 ) -> Result<(), AnyErr> {
     let mut args = vec!["shell".to_string()];
     args.push(format!("--uid={}", ctx.target_user));
-    args.extend(envvars.iter().map(|v| format!("-E{}", v)));
+    args.extend(envvars.iter().map(|v| format!("-E{v}")));
     args.push("--".to_string());
     args.push(".host".to_string());
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -22,18 +22,18 @@ pub fn have_command<P: AsRef<Path>>(exe_name: P) -> bool {
 
 fn report_command_error(err: io::Error, program: &str, args: &[String]) -> ErrorWithHint {
     ErrorWithHint::new(
-        format!("Failed to run {}: {}", program, err),
+        format!("Failed to run {program}: {err}"),
         if err.kind() == ErrorKind::NotFound {
-            format!("Try installing package that contains command '{}'", program)
+            format!("Try installing package that contains command '{program}'")
         } else {
-            format!("Complete command: {} {}", program, shell_words::join(args))
+            format!("Complete command: {program} {}", shell_words::join(args))
         },
     )
 }
 
 /// Exec command (ending the current process) or return error.
 pub fn exec_command(program: &str, args: &[String]) -> Result<(), ErrorWithHint> {
-    debug!("Executing: {} {}", program, shell_words::join(args));
+    debug!("Executing: {program} {}", shell_words::join(args));
     // If this call returns at all, it was an error
     let err: io::Error = Command::new(program).args(args).exec();
 
@@ -42,7 +42,7 @@ pub fn exec_command(program: &str, args: &[String]) -> Result<(), ErrorWithHint>
 
 /// Run command as subprocess. Return output if status was 0, otherwise return as error.
 pub fn run_command(program: &str, args: &[String]) -> Result<Output, ErrorWithHint> {
-    debug!("Running: {} {}", program, shell_words::join(args));
+    debug!("Running: {program} {}", shell_words::join(args));
     let ret = Command::new(program)
         .args(args)
         .output()
@@ -51,12 +51,11 @@ pub fn run_command(program: &str, args: &[String]) -> Result<Output, ErrorWithHi
     if !ret.status.success() {
         return Err(ErrorWithHint::new(
             format!(
-                "{} returned {}:\n{}",
-                program,
+                "{program} returned {}:\n{}",
                 ret.status.code().unwrap_or(999),
                 String::from_utf8_lossy(&ret.stderr).trim()
             ),
-            format!("Complete command: {} {}", program, shell_words::join(args)),
+            format!("Complete command: {program} {}", shell_words::join(args)),
         ));
     }
     Ok(ret)


### PR DESCRIPTION
Fixes https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args

Also configures Clippy `allow-mixed-uninlined-format-args` (in `.clippy.toml`)