### PR TITLE
Distro packaging: tmpfiles conf to create ego user home directory

### DIFF
--- a/varia/README.md
+++ b/varia/README.md
@@ -18,7 +18,7 @@ And a separate group `ego-users` for users that are allowed to invoke commands a
 
 The `ego.sysusers.conf` and `ego.tmpfiles.conf` drop-in files should create them on distros that
 The `ego.sysusers.conf` and `ego.tmpfiles.conf` drop-in files should create them on distros that
-support sysusers.d. The sudoers and polkit rules files then permit switching users.
+support sysusers.d and tmpfiles.d. The sudoers and polkit rules files then permit switching users.
 
 * `ego.sysusers.conf` → `/usr/lib/sysusers.d/ego.conf`
 * `ego.tmpfiles.conf` → `/usr/lib/tmpfiles.d/ego.conf`

--- a/varia/README.md
+++ b/varia/README.md
@@ -16,10 +16,12 @@ The following files are helpful for distribution packagers, so ego can work seam
 Distro packages should auto-create the `ego` user with low UID (<1000) and home `/home/ego`.
 And a separate group `ego-users` for users that are allowed to invoke commands as `ego`.
 
-The `ego.sysusers` drop-in file should create them on distros that support sysusers.d.
-The sudoers and polkit rules files then permit switching users.
+The `ego.sysusers.conf` and `ego.tmpfiles.conf` drop-in files should create them on distros that
+The `ego.sysusers.conf` and `ego.tmpfiles.conf` drop-in files should create them on distros that
+support sysusers.d. The sudoers and polkit rules files then permit switching users.
 
 * `ego.sysusers.conf` → `/usr/lib/sysusers.d/ego.conf`
+* `ego.tmpfiles.conf` → `/usr/lib/tmpfiles.d/ego.conf`
 * `ego.sudoers` → `/etc/sudoers.d/50_ego`
 * `ego.rules` → `/usr/share/polkit-1/rules.d/50-ego.rules`
 

--- a/varia/ego.tmpfiles.conf
+++ b/varia/ego.tmpfiles.conf
@@ -1,0 +1,2 @@
+# Alter Ego: run desktop applications under a different local user
+d /home/ego 0700 ego ego -


### PR DESCRIPTION
Add tmpfiles.d configuration file to create the `/home/ego` directory for `ego` user.

Fixes #131, turns out `sysusers.d` doesn't create the home directory https://man.archlinux.org/man/sysusers.d.5#Home_Directory

> systemd-sysusers only sets the home directory record in the user database. To actually create the directory, consider adding a corresponding [tmpfiles.d(5)](https://man.archlinux.org/man/tmpfiles.d.5.en) fragment.
