### PR TITLE
Replace unmaintained 'users' crate with nix::user

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "4.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,11 +138,11 @@ dependencies = [
  "clap",
  "clap_complete",
  "log",
+ "nix",
  "posix-acl",
  "shell-words",
  "simple-error",
  "snapbox",
- "users",
 ]
 
 [[package]]
@@ -206,6 +212,18 @@ name = "log"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+
+[[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "static_assertions",
+]
 
 [[package]]
 name = "normalize-line-endings"
@@ -278,20 +296,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "users"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
-dependencies = [
- "libc",
- "log",
-]
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,13 @@ categories = ["command-line-utilities"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-users = "0.11.0"
 simple-error = "0.3.0"
 posix-acl = "1.1.0"
 clap = "~4.3.8"
 log = { version = "0.4.19", features = ["std"] }
 ansi_term = "0.12.1"
 shell-words = "1.1.0"
+nix = { version = "0.26.2", default-features = false, features = ["user"] }
 
 [features]
 default = []

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,7 @@ fn getenv_path(key: &str) -> Result<PathBuf, SimpleError> {
 
 /// Get details of *target* user; on error, formats a nice user-friendly message with instructions.
 fn get_target_user(username: &str) -> Result<User, AnyErr> {
-    if let Some(user) = User::from_name(&username)? {
+    if let Some(user) = User::from_name(username)? {
         return Ok(user);
     }
 


### PR DESCRIPTION
See advisory [RUSTSEC-2023-0040](https://rustsec.org/advisories/RUSTSEC-2023-0040.html).

`nix::user` is more appropriate for us than `sysinfo`, because we only care about *nix support.
