### PR TITLE
Replace unmaintained 'ansi_term' crate with 'anstyle'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,15 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,7 +125,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 name = "ego"
 version = "1.1.6"
 dependencies = [
- "ansi_term",
+ "anstyle",
  "clap",
  "clap_complete",
  "log",
@@ -312,28 +303,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ simple-error = "0.3.0"
 posix-acl = "1.1.0"
 clap = "~4.3.8"
 log = { version = "0.4.19", features = ["std"] }
-ansi_term = "0.12.1"
 shell-words = "1.1.0"
 nix = { version = "0.26.2", default-features = false, features = ["user"] }
+anstyle = "1.0.1"
 
 [features]
 default = []

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,12 +1,15 @@
 //! Error handling helpers and the `ErrorWithHint` type for more verbose error messages.
 
-use ansi_term::Colour::Green;
+use crate::util::paint;
+use anstyle::{AnsiColor, Color, Style};
 use log::error;
 use std::error::Error;
 use std::fmt;
 
 /// Shorter alias for `Box<dyn Error>`
 pub type AnyErr = Box<dyn Error>;
+
+const COLOR_HINT: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Green)));
 
 /// Advanced error type that can supply hints to the user
 #[derive(Debug)]
@@ -29,7 +32,7 @@ impl fmt::Display for ErrorWithHint {
         self.err.fmt(f)?;
 
         if !self.hint.is_empty() {
-            write!(f, "\n{}: {}", Green.paint("hint"), self.hint)?;
+            write!(f, "\n{}: {}", paint(COLOR_HINT, "error"), self.hint)?;
         }
         Ok(())
     }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,12 +1,17 @@
 //! Logging for command line output.
 //! Adapted from simple_logger by Sam Clements: https://github.com/borntyping/rust-simple_logger
 
-use ansi_term::Colour::{Purple, Red, Yellow};
+use crate::util::paint;
+use anstyle::{AnsiColor, Color, Style};
 use log::{trace, Level, Log, Metadata, Record};
 
 struct SimpleLogger {
     level: Level,
 }
+
+const COLOR_TRACE: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Magenta)));
+const COLOR_WARN: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Yellow)));
+const COLOR_ERROR: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Red)));
 
 impl Log for SimpleLogger {
     fn enabled(&self, metadata: &Metadata) -> bool {
@@ -24,13 +29,13 @@ impl Log for SimpleLogger {
                 } else {
                     record.target()
                 };
-                println!("[{}] {}", Purple.paint(target), record.args());
+                println!("[{}] {}", paint(COLOR_TRACE, target), record.args());
             }
             Level::Warn => {
-                println!("{}: {}", Yellow.paint("warning"), record.args());
+                println!("{}: {}", paint(COLOR_WARN, "warning"), record.args());
             }
             Level::Error => {
-                println!("{}: {}", Red.paint("error"), record.args());
+                println!("{}: {}", paint(COLOR_ERROR, "error"), record.args());
             }
             _ => {
                 println!("{}", record.args());

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,7 +10,7 @@ use std::{env, io};
 
 /// Paint string `content` with ANSI colors `style` for printing to console.
 pub fn paint(style: Style, content: impl Display) -> String {
-    return format!("{}{}{}", style.render(), content, style.render_reset());
+    format!("{}{}{}", style.render(), content, style.render_reset())
 }
 
 /// Detect if system was booted with systemd init system. Same logic as sd_booted() in libsystemd.

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,7 @@
 use crate::ErrorWithHint;
-use anstyle::{Style};
+use anstyle::Style;
 use log::debug;
-use std::fmt::{Display};
+use std::fmt::Display;
 use std::io::ErrorKind;
 use std::os::unix::prelude::CommandExt;
 use std::path::Path;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,10 +1,17 @@
 use crate::ErrorWithHint;
+use anstyle::{Style};
 use log::debug;
+use std::fmt::{Display};
 use std::io::ErrorKind;
 use std::os::unix::prelude::CommandExt;
 use std::path::Path;
 use std::process::{Command, Output};
 use std::{env, io};
+
+/// Paint string `content` with ANSI colors `style` for printing to console.
+pub fn paint(style: Style, content: impl Display) -> String {
+    return format!("{}{}{}", style.render(), content, style.render_reset());
+}
 
 /// Detect if system was booted with systemd init system. Same logic as sd_booted() in libsystemd.
 /// https://www.freedesktop.org/software/systemd/man/sd_booted.html


### PR DESCRIPTION
See advisory [RUSTSEC-2021-0139](https://rustsec.org/advisories/RUSTSEC-2021-0139.html).

This avoids any additional dependencies: `anstyle` is already a dependency because ego uses `clap`.
