### PR TITLE
Warn if target user home directory is not accessible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,7 @@ dependencies = [
  "shell-words",
  "simple-error",
  "snapbox",
+ "testing_logger",
 ]
 
 [[package]]
@@ -297,6 +298,15 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "testing_logger"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d92b727cb45d33ae956f7f46b966b25f1bc712092aeef9dba5ac798fc89f720"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ default = []
 [dev-dependencies]
 clap_complete = "~4.3.1"
 snapbox = "0.4.11"
+testing_logger = "0.1.1"

--- a/src/snapshots/check_user_homedir.txt
+++ b/src/snapshots/check_user_homedir.txt
@@ -1,0 +1,7 @@
+INFO: TEST: Success (no output)
+INFO: TEST: Home does not exist
+WARN: User nope home directory /tmp/path-does-not-exist.example is not accessible: No such file or directory (os error 2)
+INFO: TEST: Permission denied
+INFO: User root home directory /root/path-is-not-accessible.example is not accessible: Permission denied (os error 13)
+INFO: TEST: Wrong owner
+WARN: User root home directory /root has incorrect ownership (expected UID 1234, found 0)

--- a/varia/Dockerfile.tests
+++ b/varia/Dockerfile.tests
@@ -8,7 +8,14 @@ ENV RUSTFLAGS="-D warnings"
 RUN apt-get update && \
     apt-get install -y libacl1-dev && \
     rm -rf /var/lib/apt/lists/*
+
+# Build as unprivileged user
+RUN useradd build --create-home
+WORKDIR /home/build
+USER build
+
 RUN rustup component add rustfmt clippy
+
 # Build Cargo dependencies for cache
 COPY Cargo.toml Cargo.lock ./
 RUN mkdir src/ && \


### PR DESCRIPTION
Adds additional log output when target user's home directory seems incorrectly configured. This would make issues like #131 less puzzling.

* Also added snapshot tests for log output using new `testing_logger` dependency.
* Also using an unprivileged user to build in Docker, as tests assume `/root/` directory is not permitted.
