### PR TITLE
Add --version CLI option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,7 @@ dependencies = [
  "anstyle",
  "bitflags",
  "clap_lex",
+ "once_cell",
  "strsim",
 ]
 
@@ -222,6 +223,12 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "once_cell"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "posix-acl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["command-line-utilities"]
 [dependencies]
 simple-error = "0.3.0"
 posix-acl = "1.1.0"
-clap = "~4.3.8"
+clap = { version = "~4.3.8", features = ["cargo"] }
 log = { version = "0.4.19", features = ["std"] }
 shell-words = "1.1.0"
 nix = { version = "0.26.2", default-features = false, features = ["user"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{Arg, ArgAction, ArgGroup, Command, ValueHint};
+use clap::{command, Arg, ArgAction, ArgGroup, Command, ValueHint};
 use log::Level;
 use std::ffi::OsString;
 
@@ -18,9 +18,7 @@ pub struct Args {
 }
 
 pub fn build_cli() -> Command {
-    Command::new("ego")
-        .about("Alter Ego: run desktop applications under a different local user")
-        .disable_version_flag(true)
+    command!()
         .arg(
             Arg::new("user")
                 .short('u')

--- a/src/snapshots/ego.help
+++ b/src/snapshots/ego.help
@@ -1,4 +1,4 @@
-Alter Ego: run desktop applications under a different local user
+Alter Ego: run Linux desktop applications under a different local user
 
 Usage: ego [OPTIONS] [command]...
 
@@ -12,3 +12,4 @@ Options:
       --machinectl-bare  Use 'machinectl' but skip xdg-desktop-portal setup
   -v, --verbose...       Verbose output. Use multiple times for more output.
   -h, --help             Print help
+  -V, --version          Print version

--- a/varia/ego-completion.bash
+++ b/varia/ego-completion.bash
@@ -19,7 +19,7 @@ _ego() {
 
     case "${cmd}" in
         ego)
-            opts="-u -v -h --user --sudo --machinectl --machinectl-bare --verbose --help [command]..."
+            opts="-u -v -h -V --user --sudo --machinectl --machinectl-bare --verbose --help --version [command]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/varia/ego-completion.fish
+++ b/varia/ego-completion.fish
@@ -4,3 +4,4 @@ complete -c ego -l machinectl -d 'Use \'machinectl\' to change user (default, if
 complete -c ego -l machinectl-bare -d 'Use \'machinectl\' but skip xdg-desktop-portal setup'
 complete -c ego -s v -l verbose -d 'Verbose output. Use multiple times for more output.'
 complete -c ego -s h -l help -d 'Print help'
+complete -c ego -s V -l version -d 'Print version'

--- a/varia/ego-completion.zsh
+++ b/varia/ego-completion.zsh
@@ -24,6 +24,8 @@ _ego() {
 '*--verbose[Verbose output. Use multiple times for more output.]' \
 '-h[Print help]' \
 '--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
 '*::command -- Command name and arguments to run (default\: user shell):_cmdambivalent' \
 && ret=0
 }


### PR DESCRIPTION
Version number is now automatically read from `Cargo.toml` file, using clap's [`command!()`](https://docs.rs/clap/latest/clap/macro.command.html) macro.

Also reading project description from `Cargo.toml` now.
