### PR TITLE
Use bold in CLI colors

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,7 +9,9 @@ use std::fmt;
 /// Shorter alias for `Box<dyn Error>`
 pub type AnyErr = Box<dyn Error>;
 
-const COLOR_HINT: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Green)));
+const COLOR_HINT: Style = Style::new()
+    .fg_color(Some(Color::Ansi(AnsiColor::Green)))
+    .bold();
 
 /// Advanced error type that can supply hints to the user
 #[derive(Debug)]

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -10,8 +10,12 @@ struct SimpleLogger {
 }
 
 const COLOR_TRACE: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Magenta)));
-const COLOR_WARN: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Yellow)));
-const COLOR_ERROR: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Red)));
+const COLOR_WARN: Style = Style::new()
+    .fg_color(Some(Color::Ansi(AnsiColor::Yellow)))
+    .bold();
+const COLOR_ERROR: Style = Style::new()
+    .fg_color(Some(Color::Ansi(AnsiColor::Red)))
+    .bold();
 
 impl Log for SimpleLogger {
     fn enabled(&self, metadata: &Metadata) -> bool {


### PR DESCRIPTION
Makes warnings/errors a bit more visible.
