### PR TITLE
chore(deps): update clap & clap_complete to latest 4.5.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
@@ -86,18 +86,18 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
 dependencies = [
  "anstream",
  "anstyle",
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.2"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79504325bf38b10165b02e89b4347300f855f273c4cb30c4a3209e6583275e"
+checksum = "d9647a559c112175f17cf724dc72d3645680a883c58481332779192b0d8e7a01"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["command-line-utilities"]
 [dependencies]
 simple-error = "0.3.0"
 posix-acl = "1.2.0"
-clap = { version = "~4.5.4", features = ["cargo"] }
+clap = { version = "~4.5.21", features = ["cargo"] }
 log = { version = "0.4.20", features = ["std"] }
 shell-words = "1.1.0"
 nix = { version = "0.29.0", default-features = false, features = ["user"] }
@@ -29,6 +29,6 @@ xcb = "1.4.0"
 default = []
 
 [dev-dependencies]
-clap_complete = "~4.5.2"
+clap_complete = "~4.5.38"
 snapbox = "0.6.7"
 testing_logger = "0.1.1"

--- a/varia/ego-completion.zsh
+++ b/varia/ego-completion.zsh
@@ -14,7 +14,7 @@ _ego() {
     fi
 
     local context curcontext="$curcontext" state line
-    _arguments "${_arguments_options[@]}" \
+    _arguments "${_arguments_options[@]}" : \
 '-u+[Specify a username (default\: ego)]:USER:_users' \
 '--user=[Specify a username (default\: ego)]:USER:_users' \
 '--sudo[Use '\''sudo'\'' to change user]' \


### PR DESCRIPTION
Required updating zsh completions file. Fixes build failure in:

* #164
* #152