### PR TITLE
tool(renovate): tweaks & bump version in Cargo.toml also

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,9 @@
 {
   "extends": [
-    "config:base"
+    "mergeConfidence:all-badges",
+    "config:recommended"
   ],
+  "rangeStrategy": "bump",
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["before 5am on saturday"]
@@ -9,7 +11,7 @@
   "packageRules": [
     {
       "matchManagers": ["cargo"],
-      "matchPackageNames": ["clap", "clap_complete"],
+      "matchPackageNames": ["clap", "clap_complete", "clap_builder", "clap_lex"],
       "groupName": "Clap updates"
     },
     {


### PR DESCRIPTION
Renovate configuration changes:

* Bump version in Cargo.toml in addition to Cargo.lock (`rangeStrategy=bump`)
* Update list of `clap` packages.
* Update to Renovate's suggested `extends` configuration: adding "Merge Confidence" badges.

Documentation about `rangeStrategy`:

* Default: https://docs.renovatebot.com/modules/manager/cargo/
* https://docs.renovatebot.com/configuration-options/#rangestrategy