### PR TITLE
chore(clippy): run Clippy with all targets & features; fix warnings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,6 @@ jobs:
       - name: Test suite
         run: docker run --rm ego-build cargo test --color=always
       - name: Clippy lints
-        run: docker run --rm ego-build cargo clippy --color=always
+        run: docker run --rm ego-build cargo clippy --color=always --all-targets --all-features -- -D warnings
       - name: rustfmt
         run: docker run --rm ego-build cargo fmt -- --color=always --check

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 #![warn(clippy::pedantic)]
+#![warn(clippy::cargo)]
 #![allow(clippy::module_name_repetitions)]
+#![allow(clippy::multiple_crate_versions)]
 
 #[macro_use]
 extern crate simple_error;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -28,11 +28,11 @@ fn snapshot() -> &'static Assert {
 fn assert_log_snapshot(expected_path: &Data) {
     testing_logger::validate(|logs| {
         let output = logs.iter().fold(String::new(), |mut a, b| {
-            write!(a, "{}: {}\n", b.level.as_str(), b.body).unwrap();
+            writeln!(a, "{}: {}", b.level.as_str(), b.body).unwrap();
             a
         });
         snapshot().eq(output, expected_path);
-    })
+    });
 }
 
 fn render_completion(generator: impl Generator) -> Data {
@@ -171,10 +171,10 @@ fn test_have_command() {
 #[test]
 fn test_check_user_homedir() {
     let ctx = EgoContext {
-        runtime_dir: Default::default(),
+        runtime_dir: PathBuf::default(),
         target_user: "root".to_string(),
         target_uid: 0,
-        target_user_shell: Default::default(),
+        target_user_shell: PathBuf::default(),
         target_user_homedir: "/root".into(),
     };
 


### PR DESCRIPTION
* Turns out clippy needs `--all-targets --all-features` to scan tests
* Also enabled `clippy::cargo` lints group
* Fixed all found warnings