### PR TITLE
chore: update to Rust edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ego"
 version = "1.2.0"
-edition = "2021"
-rust-version = "1.74.0"
+edition = "2024"
+rust-version = "1.85.0"
 
 # Metadata
 authors = ["Marti Raudsepp <marti@juffo.org>"]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{command, Arg, ArgAction, ArgGroup, Command, ValueHint};
+use clap::{Arg, ArgAction, ArgGroup, Command, ValueHint, command};
 use log::Level;
 use std::ffi::OsString;
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -3,7 +3,7 @@
 
 use crate::util::paint;
 use anstyle::{AnsiColor, Color, Style};
-use log::{trace, Level, Log, Metadata, Record};
+use log::{Level, Log, Metadata, Record, trace};
 
 struct SimpleLogger {
     level: Level,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,14 +6,14 @@
 #[macro_use]
 extern crate simple_error;
 
-use crate::cli::{parse_args, Method};
-use crate::errors::{print_error, AnyErr, ErrorWithHint};
+use crate::cli::{Method, parse_args};
+use crate::errors::{AnyErr, ErrorWithHint, print_error};
 use crate::util::{exec_command, have_command, sd_booted};
 use crate::x11::{x11_add_acl_with_fallback, x11_xhost_add_acl};
-use log::{debug, info, log, warn, Level};
+use log::{Level, debug, info, log, warn};
 use nix::libc::uid_t;
 use nix::unistd::{Uid, User};
-use posix_acl::{PosixACL, Qualifier, ACL_EXECUTE, ACL_READ, ACL_RWX};
+use posix_acl::{ACL_EXECUTE, ACL_READ, ACL_RWX, PosixACL, Qualifier};
 use simple_error::SimpleError;
 use std::env::VarError;
 use std::fs::{DirBuilder, Metadata};
@@ -243,7 +243,10 @@ fn prepare_x11(ctx: &EgoContext, old_xhost: bool) -> Result<Vec<String>, AnyErr>
     }
 
     if old_xhost {
-        warn!("--old-xhost is deprecated. If there are issues with the new method, please report a bug.");
+        warn!(
+            "--old-xhost is deprecated. \
+            If there are issues with the new method, please report a bug."
+        );
         x11_xhost_add_acl("localuser", &ctx.target_user)?;
     } else {
         x11_add_acl_with_fallback("localuser", &ctx.target_user)?;
@@ -420,12 +423,14 @@ fn run_machinectl_command(
     args.push("/bin/sh".to_string());
     args.push("-c".to_string());
     let remote_cmd = if remote_cmd.is_empty() {
-        vec![require_with!(
-            ctx.target_user_shell.to_str(),
-            "User '{}' shell has unexpected characters",
-            ctx.target_user
-        )
-        .to_string()]
+        vec![
+            require_with!(
+                ctx.target_user_shell.to_str(),
+                "User '{}' shell has unexpected characters",
+                ctx.target_user
+            )
+            .to_string(),
+        ]
     } else {
         remote_cmd
     };

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -2,7 +2,7 @@ use log::{debug, warn};
 use xcb::x::{ChangeHosts, Family, HostMode};
 use xcb::{ConnError, Connection};
 
-use crate::errors::{print_error, AnyErr, ErrorWithHint};
+use crate::errors::{AnyErr, ErrorWithHint, print_error};
 use crate::util::run_command;
 
 /// Try `libxcb`, fall back to `xhost`.


### PR DESCRIPTION
* Bump minimum supported Rust version to 1.85.0
* Tests: Wrap environment-modifying calls with `unsafe {}` & add code comment
* Reformatted imports
* Small `rustfmt` formatting changes